### PR TITLE
Add pod priority class csm-high-priority-service to istio charts

### DIFF
--- a/kubernetes/cray-istio-deploy/values.yaml
+++ b/kubernetes/cray-istio-deploy/values.yaml
@@ -31,6 +31,7 @@ istio:
 
   global:
     imagePullPolicy: IfNotPresent
+    priorityClassName: csm-high-priority-service
 
   sidecarInjectorWebhook:
     rewriteAppHTTPProbe: true

--- a/kubernetes/cray-istio-operator/README.md
+++ b/kubernetes/cray-istio-operator/README.md
@@ -2,10 +2,15 @@
 This deploys the Istio operator. There are instructions here:
 https://istio.io/v1.7/docs/setup/install/operator/
 
-The istio-operator chart in the charts/ directory was copied from the istio
-release which is available for download at
+The istio-operator chart in the charts/ directory was copied (and modified -- see
+details below) from the istio release which is available for download at
 https://github.com/istio/istio/releases/ .
 The chart is in `manifests/charts/istio-operator`.
+
+# Changes from upstream chart:
+
+In order to support pod priorities the deployment.yaml and values.yaml files
+have been modified from upstream to support a priorityClassName.
 
 # Recreate IstioOperator CRD on upgrade
 
@@ -15,3 +20,4 @@ checks for the condition and runs kubectl apply to recreate the
 IstioOperator CRD.
 
 This can probably be removed in the next Istio upgrade.
+

--- a/kubernetes/cray-istio-operator/charts/istio-operator/templates/deployment.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
         name: istio-operator
     spec:
       serviceAccountName: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+{{- if .Values.operator.priorityClassName }}
+      priorityClassName: "{{ .Values.operator.priorityClassName }}"
+{{- end }}
       containers:
         - name: istio-operator
           image: {{.Values.hub}}/operator:{{.Values.tag}}

--- a/kubernetes/cray-istio-operator/charts/istio-operator/values.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/values.yaml
@@ -15,6 +15,7 @@ revision: ""
 
 # Operator resource defaults
 operator:
+  priorityClassName: csm-high-priority-service
   resources:
     limits:
       cpu: 200m

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -433,7 +433,7 @@ global:
   # will not be killed because of low priority class.
   # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   # for more detail.
-  priorityClassName: ""
+  priorityClassName: csm-high-priority-service
 
   # Use the Mesh Control Protocol (MCP) for configuring Mixer and Pilot. Requires an MCP source.
   useMCP: false


### PR DESCRIPTION
### Summary and Scope

Add pod priority class csm-high-priority-service to istio ingress, operator, and istiod pods

### Issues and Related PRs

* CASMPET-4256
* CASMPET-4257
* CASMPET-4255
* CASMPET-4258

### Testing

* vshasta

```
ncn-m001-21f512b8:/home/bklein # kubectl get pod -n istio-system istiod-7bb94698c6-2sv9g -o yaml | grep prior
        f:priorityClassName: {}
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

```
ncn-m001-21f512b8:/home/bklein # kubectl get po -n istio-operator istio-operator-785868b56f-xk99w -o yaml | grep prior
        f:priorityClassName: {}
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

```
ncn-m001-21f512b8:/home/bklein # kubectl -n istio-system get pod istio-ingressgateway-7b7b95d68b-cjjpv -o yaml | grep prior
        f:priorityClassName: {}
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

```
ncn-m001-21f512b8:/home/bklein # kubectl -n istio-system get pod istio-ingressgateway-hmn-574698c99-65llq -o yaml | grep prior
        f:priorityClassName: {}
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

Was a fresh Install tested? N
Was an Upgrade tested?      Y
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Fresh install