### PR TITLE
CASMPET-4822 Bump patch version of charts

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.7.8
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
-version: 1.19.1
+version: 1.19.10

--- a/kubernetes/cray-istio-operator/Chart.yaml
+++ b/kubernetes/cray-istio-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.7.8
 name: cray-istio-operator
 description: Deploys the istio operator for Cray systems.
-version: 1.19.1
+version: 1.19.10

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.7.8
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 home: "cloud/cray-charts"
-version: 1.25.2
+version: 1.25.10


### PR DESCRIPTION
These charts were previously released with various patch numbers, up to
and including 7. This is bumping them to 10 to make sure we don't pull
development charts.