### PR TITLE
CASMPET-4822 Fix incorrect hub paths

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.7.8
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
-version: 1.20.0
+version: 1.20.1

--- a/kubernetes/cray-istio-deploy/values.yaml
+++ b/kubernetes/cray-istio-deploy/values.yaml
@@ -1,5 +1,5 @@
 
-hub: dtr.dev.cray.com/cray
+hub: dtr.dev.cray.com/cray/istio
 tag: 1.7.8-cray1-distroless
 
 kubectl:
@@ -8,7 +8,7 @@ kubectl:
     tag: 0.5.1
 
 pilot:
-  hub: dtr.dev.cray.com/cray
+  hub: dtr.dev.cray.com/cray/istio
   tag: 1.7.8-cray1-distroless
 
 meshConfig:

--- a/kubernetes/cray-istio-operator/Chart.yaml
+++ b/kubernetes/cray-istio-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.7.8
 name: cray-istio-operator
 description: Deploys the istio operator for Cray systems.
-version: 1.20.0
+version: 1.20.1

--- a/kubernetes/cray-istio-operator/values.yaml
+++ b/kubernetes/cray-istio-operator/values.yaml
@@ -1,5 +1,5 @@
 istio-operator:
-  hub: dtr.dev.cray.com/cray
+  hub: dtr.dev.cray.com/cray/istio
   tag: 1.7.8-cray1-distroless
 
 kubectl:

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.7.8
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 home: "cloud/cray-charts"
-version: 1.26.0
+version: 1.26.1

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -102,7 +102,7 @@ global:
   # Releases are published to docker hub under 'istio' project,
   # build from our istio fork to the cray project in dtr.
   # Dev builds from prow are on gcr.io
-  hub: dtr.dev.cray.com/cray
+  hub: dtr.dev.cray.com/cray/istio
 
   # Default tag for Istio images.
   tag: 1.7.8-cray1-distroless


### PR DESCRIPTION
The image path for the istio images changed when moving from arti to algol60. This caused the built to put the images under cray/istio instead of just cray. This fixes the hub reference so that the images can be found by the chart.