### PR TITLE
CASMPET-4455 Bump chart versions

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: 1.7.8
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
-version: 1.21.1
+version: 1.22.0

--- a/kubernetes/cray-istio-operator/Chart.yaml
+++ b/kubernetes/cray-istio-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.7.8
 name: cray-istio-operator
 description: Deploys the istio operator for Cray systems.
-version: 1.21.1
+version: 1.22.0
 dependencies:
   - name: istio-operator
     Version: 1.7.0

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.7.8
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 home: "cloud/cray-charts"
-version: 1.27.1
+version: 2.0.0


### PR DESCRIPTION
This bumps the minor version of cray-istio-operator and cray-istio-deploy since the previous version was being used in CSM-1.1. This also does a major version bump of cray-istio since it is no longer compatible with 1.X.X.