### PR TITLE
CASMPET-5000: Bump versions for cray-istio-deploy and cray-istio for CSM 1.2 release

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: 1.7.8
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
-version: 1.22.0
+version: 1.23.0

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.7.8
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 home: "cloud/cray-charts"
-version: 2.0.0
+version: 2.1.0


### PR DESCRIPTION
This release includes the following change:

* CASMPET-3926: Stop deploying kiali add-on using istio-operator

This is the first release of cray-istio-deploy and cray-istio for
CSM-1.2.
The change is backwards-compatible, any settings that the user might
have overridden are ignored now.

Therefore the MINOR number is increased.