### PR TITLE
CASMPET-5088: Version bumps for CSM 1.2 Release

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: 1.7.8
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
-version: 1.23.0
+version: 1.24.0

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.7.8
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 home: "cloud/cray-charts"
-version: 2.1.0
+version: 2.2.0


### PR DESCRIPTION
This release includes the following change:

* CASMPET-4467: Stop deploying Istio Prometheus using the operator

This is a MINOR version increment. This is not the first release for CSM 1.2.
The change is added functionality and is backwards-compatible.