### PR TITLE
CASMPET-5103: Bump versions to prep for CSM-1.2 Release 4

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: 1.7.8
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
-version: 1.24.0
+version: 1.25.0

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.7.8
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 home: "cloud/cray-charts"
-version: 2.2.0
+version: 2.3.0


### PR DESCRIPTION
This release includes the following change:

* CASMPET-5096: Disable Jaeger : https://github.com/Cray-HPE/cray-istio/pull/18

This isn't the first release and this is a new "feature" that's
backwards compatible, so the MINOR version is incremented.