### PR TITLE
CASMPET-5104: Bump chart versions to prep for release.

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: 1.8.6
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
-version: 1.25.0
+version: 1.26.0

--- a/kubernetes/cray-istio-operator/Chart.yaml
+++ b/kubernetes/cray-istio-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.8.6
 name: cray-istio-operator
 description: Deploys the istio operator for Cray systems.
-version: 1.22.0
+version: 1.23.0
 dependencies:
   - name: istio-operator
     Version: 1.7.0

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.8.6
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 home: "cloud/cray-charts"
-version: 2.3.0
+version: 2.4.0


### PR DESCRIPTION
This release includes the following change.

* CASMPET-5104: Updates for Istio 1.8.6

I increased the MINOR number because this is a new feature.