### PR TITLE
Fixes CASMINST-3548: avoid istio from injecting fsGroup 1337 to tls

### DIFF
--- a/kubernetes/cray-istio-deploy/templates/istiooperator.yaml
+++ b/kubernetes/cray-istio-deploy/templates/istiooperator.yaml
@@ -33,6 +33,9 @@ spec:
     pilot:
       enabled: true
       k8s:
+        env:
+        - name: ENABLE_LEGACY_FSGROUP_INJECTION
+          value: "false"
         resources:
           requests:
             {{- if .Values.pilot.resources.requests.cpu }}

--- a/kubernetes/cray-istio-deploy/tests/istiooperator_test.yaml
+++ b/kubernetes/cray-istio-deploy/tests/istiooperator_test.yaml
@@ -11,13 +11,13 @@ tests:
           pattern: cray-istio$
       - equal:
           path: spec.components.pilot.hub
-          value: dtr.dev.cray.com/cray
+          value: artifactory.algol60.net/csm-docker/stable/istio
       - equal:
           path: spec.components.pilot.tag
-          value: 1.7.8-cray1-distroless
+          value: 1.8.6-cray1-distroless
       - equal:
           path: spec.hub
-          value: dtr.dev.cray.com/cray
+          value: artifactory.algol60.net/csm-docker/stable/istio
       - equal:
           path: spec.tag
-          value: 1.7.8-cray1-distroless
+          value: 1.8.6-cray1-distroless


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
After istio upgrade from 1.7.8 to 1.8.6, we ran into an issue as reported in https://github.com/istio/istio/issues/26882, by while fsGroup 1337 is injected to mounted volumes (e.g., tls). We need to set ENABLE_LEGACY_FSGROUP_INJECTION as false to avoid the unwanted injection.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._
CASMINST-3548
CASMPET-5104 (Updates for Istio 1.8.6)

* Resolves [CASMINST-3548](https://connect.us.cray.com/jira/browse/CASMINST-3548)
* Change will also be needed in `N/A`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._
drax

### Tested on:

  * `drax`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
replace the chart and verify postgres cluster was up and running

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? Fixed existing test.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

