### PR TITLE
Fixes CASMPET-5174: replace wait-for-pods with kubectl command

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.26.1
+version: 1.26.2
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
 keywords:

--- a/kubernetes/cray-istio-deploy/templates/rbac.yaml
+++ b/kubernetes/cray-istio-deploy/templates/rbac.yaml
@@ -31,8 +31,8 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["pods"]
+- apiGroups: ["", "apps"]
+  resources: ["pods", "deployments"]
   verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding

--- a/kubernetes/cray-istio-deploy/templates/wait-jobs.yaml
+++ b/kubernetes/cray-istio-deploy/templates/wait-jobs.yaml
@@ -55,4 +55,4 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - '/usr/local/bin/wait-for-pods istiod'
+            - 'kubectl rollout status deployment -n istio-system istiod --timeout=15m'

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.4.1
+version: 2.4.2
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/templates/ingress-gateway/wait-jobs.yaml
+++ b/kubernetes/cray-istio/templates/ingress-gateway/wait-jobs.yaml
@@ -27,5 +27,5 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - '/usr/local/bin/wait-for-pods {{ $name }}'
+            - 'kubectl rollout status deployment -n istio-system {{ $name }} --timeout=15m'
 {{- end }}

--- a/kubernetes/cray-istio/templates/rbac.yaml
+++ b/kubernetes/cray-istio/templates/rbac.yaml
@@ -9,8 +9,8 @@ kind: ClusterRole
 metadata:
   name: cray-istio-jobs-role
 rules:
-- apiGroups: [""]
-  resources: ["pods"]
+- apiGroups: ["", "apps"]
+  resources: ["pods", "deployments"]
   verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
While replacing loftsman with docker-kubectl image, one script "wait-for-pods" in loftsman does not exist in docker-kubectl image causing the wait pods to fail. This PR is to use an equivalent kubectl command to replace the wait-for-pods script.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards compatible bugfix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5174](https://connect.us.cray.com/jira/browse/CASMPET-5174)
* Change will also be needed in `<insert branch name here>`
* Future work required by [CASMPET-5166](https://connect.us.cray.com/jira/browse/CASMPET-5166)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._
surtur

### Tested on:

  * `surtur`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

