### PR TITLE
CASMINST-3406: Fix HorizontalPodAutoscaler template for ingress-gateways

### DIFF
--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.4.2
+version: 2.4.3
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/templates/ingress-gateway/autoscale.yaml
+++ b/kubernetes/cray-istio/templates/ingress-gateway/autoscale.yaml
@@ -1,11 +1,11 @@
-{{- if and .autoscaleEnabled .autoscaleMin .autoscaleMax }}
 {{- range $name, $options:= .Values.deployments }}
+{{- if and $options.autoscaleEnabled $options.autoscaleMin $options.autoscaleMax }}
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name }}
-  namespace: {{ $options.namespace | default .Release.Namespace }}
+  namespace: {{ $options.namespace | default $.Release.Namespace }}
   labels:
 {{ .labels | toYaml | indent 4 }}
     release: {{ $.Release.Name }}


### PR DESCRIPTION
## Summary and Scope

Fixed a bug in the autoscale.yaml template so the HorizontalPodAutoscaler resources get created for all of the ingressgateways.

This is a backwards compatible bugfix.

## Issues and Related PRs

* Resolves CASMINST-3406

## Testing

### Tested on:

  * `wasp`

### Test description:

The development build of the new chart was deployed on wasp and I verified that the HorizontalPodAutoscalers were created and each of the ingressgateway deployments now has 3 pods running (previous each only had 1 pod).

## Risks and Mitigations

Low risk.  If an unforeseen issue is encountered, the chart can be rolled back.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

