### PR TITLE
CASMINST-3852 Update hmn istio label 

### DIFF
--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
 version: 2.5.0
 name: cray-istio

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.4.3
+version: 2.5.0
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -196,7 +196,7 @@ deployments:
     enabled: true
     labels:
       app: istio-ingressgateway-hmn
-      istio: ingressgateway-hmn
+      istio: istio-ingressgateway-hmn
     autoscaleEnabled: true
     autoscaleMin: 3
     autoscaleMax: 6
@@ -295,7 +295,7 @@ gateways:
   hmn-gateway:
     namespace: services
     selector:
-      istio: ingressgateway-hmn
+      istio: istio-ingressgateway-hmn
     labels:
       app: istio-ingressgateway
       gateway: hmn-gateway
@@ -411,10 +411,10 @@ services:
     gateway: istio-ingressgateway-hmn
     selectors:
       app: istio-ingressgateway-hmn
-      istio: ingressgateway-hmn
+      istio: istio-ingressgateway-hmn
     labels:
       app: istio-ingressgateway-hmn
-      istio: ingressgateway-hmn
+      istio: istio-ingressgateway-hmn
       peerauthentication: ingressgateway
     externalTrafficPolicy: "Cluster"
     type: LoadBalancer

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -1,13 +1,18 @@
+#
 # MIT License
-# (C) Copyright [2021] Hewlett Packard Enterprise Development LP
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -15,7 +20,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-
+#
 # Default values for cray-istio.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.


### PR DESCRIPTION
## Summary and Scope

This reverts the istio-ingressgateway-hmn label to how it was in the previous istio charts. This allows us to upgrade without deleting istio-ingressgateway-hmn first.

## Issues and Related PRs

* Resolves [CASMINST-3852](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3852)

## Testing


### Tested on:

  * Virtual Shasta

### Test description:

Validated the upgrade could occur without an error about the labels changing.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

