### PR TITLE
CASMPET-5303: Upgrade Istio to 1.9.9

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.26.3
+version: 1.27.0
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
 keywords:
@@ -31,16 +31,16 @@ home: https://github.com/Cray-HPE/cray-istio
 sources:
   - https://github.com/Cray-HPE/cray-istio
 maintainers:
-  - name: brantk-hpe
-appVersion: 1.8.6
+  - name: bo-quan
+appVersion: 1.9.9
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: istio-pilot-distro
-      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.8.6-cray2-distroless
+      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.9.9-cray1-distroless
     - name: istio-pilot-distroless
-      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.8.6-cray2
+      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.9.9-cray1
     - name: istio-proxy-distro
-      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
+      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
     - name: istio-proxy-distroless
-      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2
+      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1

--- a/kubernetes/cray-istio-deploy/tests/istiooperator_test.yaml
+++ b/kubernetes/cray-istio-deploy/tests/istiooperator_test.yaml
@@ -37,10 +37,10 @@ tests:
           value: artifactory.algol60.net/csm-docker/stable/istio
       - equal:
           path: spec.components.pilot.tag
-          value: 1.8.6-cray1-distroless
+          value: 1.9.9-cray1-distroless
       - equal:
           path: spec.hub
           value: artifactory.algol60.net/csm-docker/stable/istio
       - equal:
           path: spec.tag
-          value: 1.8.6-cray1-distroless
+          value: 1.9.9-cray1-distroless

--- a/kubernetes/cray-istio-deploy/values.yaml
+++ b/kubernetes/cray-istio-deploy/values.yaml
@@ -23,7 +23,7 @@
 #
 ---
 hub: artifactory.algol60.net/csm-docker/stable/istio
-tag: 1.8.6-cray2-distroless   # Also update the proxyv2 annotations in Chart.yaml
+tag: 1.9.9-cray1-distroless   # Also update the proxyv2 annotations in Chart.yaml
 
 kubectl:
   image:
@@ -32,7 +32,7 @@ kubectl:
 
 pilot:
   hub: artifactory.algol60.net/csm-docker/stable/istio
-  tag: 1.8.6-cray2-distroless   # Also update the pilot annotations in Chart.yaml
+  tag: 1.9.9-cray1-distroless   # Also update the pilot annotations in Chart.yaml
   resources:
     requests:
       cpu:

--- a/kubernetes/cray-istio-operator/Chart.yaml
+++ b/kubernetes/cray-istio-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.23.2
+version: 1.24.0
 name: cray-istio-operator
 description: Helm chart for deploying Istio operator
 keywords:
@@ -35,10 +35,10 @@ dependencies:
   - name: istio-operator
     version: 1.7.0
 maintainers:
-  - name: brantk-hpe
-appVersion: 1.8.6
+  - name: bo-quan
+appVersion: 1.9.9
 annotations:
   artifacthub.io/images: |
     - name: istio-operator-distro
-      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.8.6-cray2
+      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.9.9-cray1
   artifacthub.io/license: MIT

--- a/kubernetes/cray-istio-operator/README.md
+++ b/kubernetes/cray-istio-operator/README.md
@@ -1,6 +1,6 @@
 
 This deploys the Istio operator. There are instructions here:
-https://istio.io/v1.8/docs/setup/install/operator/
+https://istio.io/v1.9/docs/setup/install/operator/
 
 The istio-operator chart in the charts/ directory was copied (and modified -- see
 details below) from the istio release which is available for download at

--- a/kubernetes/cray-istio-operator/charts/istio-operator/files/gen-operator.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/files/gen-operator.yaml
@@ -75,9 +75,7 @@ rules:
   - daemonsets
   - deployments
   - deployments/finalizers
-  - ingresses
   - replicasets
-  - statefulsets
   verbs:
   - '*'
 - apiGroups:
@@ -183,7 +181,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: gcr.io/istio-testing/operator:1.8-dev
+          image: gcr.io/istio-testing/operator:1.9-dev
           command:
           - operator
           - server
@@ -217,6 +215,6 @@ spec:
             - name: OPERATOR_NAME
               value: "istio-operator"
             - name: WAIT_FOR_RESOURCES_TIMEOUT
-              value: "300s"
+              value: "600s"
             - name: REVISION
               value: ""

--- a/kubernetes/cray-istio-operator/charts/istio-operator/templates/clusterrole.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/templates/clusterrole.yaml
@@ -57,9 +57,7 @@ rules:
   - daemonsets
   - deployments
   - deployments/finalizers
-  - ingresses
   - replicasets
-  - statefulsets
   verbs:
   - '*'
 - apiGroups:

--- a/kubernetes/cray-istio-operator/tests/deployment_test.yaml
+++ b/kubernetes/cray-istio-operator/tests/deployment_test.yaml
@@ -34,4 +34,4 @@ tests:
           pattern: istio-operator$
       - equal:
           path: spec.template.spec.containers[0].image
-          value: artifactory.algol60.net/csm-docker/stable/istio/operator:1.8.6-cray1-distroless
+          value: artifactory.algol60.net/csm-docker/stable/istio/operator:1.9.9-cray1-distroless

--- a/kubernetes/cray-istio-operator/values.yaml
+++ b/kubernetes/cray-istio-operator/values.yaml
@@ -23,7 +23,7 @@
 #
 istio-operator:
   hub: artifactory.algol60.net/csm-docker/stable/istio
-  tag: 1.8.6-cray2-distroless  # Also update the annotation in Chart.yaml
+  tag: 1.9.9-cray1-distroless  # Also update the annotation in Chart.yaml
 
 kubectl:
   image:

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 2.5.0
+version: 2.6.0
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:
@@ -31,7 +31,7 @@ home: https://github.com/Cray-HPE/cray-istio
 sources:
   - https://github.com/Cray-HPE/cray-istio
 maintainers:
-  - name: brantk-hpe
-appVersion: 1.8.6
+  - name: bo-quan
+appVersion: 1.9.9
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-istio/tests/kuttl/deployment/00-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/00-assert.yaml
@@ -191,7 +191,7 @@ spec:
               value: sni-dnat
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
+          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:

--- a/kubernetes/cray-istio/tests/kuttl/deployment/01-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/01-assert.yaml
@@ -191,7 +191,7 @@ spec:
               value: sni-dnat
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
+          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:

--- a/kubernetes/cray-istio/tests/kuttl/deployment/02-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/02-assert.yaml
@@ -190,7 +190,7 @@ spec:
               value: sni-dnat
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
+          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:

--- a/kubernetes/cray-istio/tests/kuttl/deployment/03-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/03-assert.yaml
@@ -198,7 +198,7 @@ spec:
           value: sni-dnat
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
+        image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -525,7 +525,7 @@ global:
   hub: artifactory.algol60.net/csm-docker/stable/istio
 
   # Default tag for Istio images.
-  tag: 1.8.6-cray2-distroless
+  tag: 1.9.9-cray1-distroless
 
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components


### PR DESCRIPTION
## Summary and Scope

Upgrade Istio to 1.9.9. Minor versions for the 3 istio charts included in this upgrade have been bumped.

## Issues and Related PRs

* Resolves [CASMPET-5303]
* Change will also be needed in `<insert branch name here>`

## Testing

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

Upgraded Istio, opa, and kiali charts, and verified that token obtained from keycloak worked for api calls (e.g., capmc.) Also validated the login to Istio, grafana, keycloak, prometheus, and kiali continued to work, and showed the new versions.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Medium. It's a one-version upgrade for Istio, and validated in both bare metal and vshasta testing. Since we still have a few weeks of testing time for 1.2.5, the risk is minimized in case we run into any unexpected issues for 1.2.5 release.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

