### PR TITLE
CASMINST-4742 Enable required pod anti-affinity

### DIFF
--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 2.6.0
+version: 2.6.1
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/templates/ingress-gateway/deployment.yaml
+++ b/kubernetes/cray-istio/templates/ingress-gateway/deployment.yaml
@@ -341,8 +341,10 @@ spec:
       {{- end }}
       affinity:
       {{- include "nodeaffinity" (dict "global" $.Values.global "nodeSelector" $options.nodeSelector) | indent 6 }}
-        {{- if $options.podAffinityTerm }}
+        {{- if or $options.podAffinityTerm $options.podAntiAffinity }}
         podAntiAffinity:
+        {{- end }}
+          {{- if $options.podAffinityTerm }}
           preferredDuringSchedulingIgnoredDuringExecution:
             {{- range $k, $v := $options.podAffinityTerm }}
             - podAffinityTerm:
@@ -361,26 +363,22 @@ spec:
                 {{- end }}
               weight: {{ $v.weight | default 100 }}
                     {{- end }}
-            {{- end }}
-        {{- if $options.podAntiAffinity }}
-        podAntiAffinity:
+          {{- end }}
+          {{- if $options.podAntiAffinity }}
           requiredDuringSchedulingIgnoredDuringExecution:
+            {{- range $k, $v := $options.podAntiAffinity }}
             - labelSelector:
                 matchExpressions:
-                  {{- range $k, $v := $options.podAntiAffinity }}
                   - key: {{ $v.key }}
                     operator: {{ $v.operator }}
                     values:
                       {{- $vals := split "," $v.values }}
-                      {{- range $i, $item := $vals }}
-                      - {{ $item | quote }}
+                      {{- range $i, $v := $vals }}
+                      - {{ $v | quote }}
                       {{- end }}
-                    topologyKey: {{ $v.topologyKey | default "kubernetes.io/hostname" }}
-              {{- if $v.namespaces }}
-              namespaces: {{ $v.namespaces }}
-              {{- end }}
-                {{- end }}
-        {{- end }}
+              topologyKey: {{ $v.topologyKey | default "kubernetes.io/hostname" }}
+            {{- end }}
+         {{- end }}
 {{- if $options.tolerations }}
       tolerations:
 {{ toYaml $options.tolerations | indent 6 }}

--- a/kubernetes/cray-istio/tests/kuttl/deployment/00-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/00-assert.yaml
@@ -92,15 +92,6 @@ spec:
             - podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - istio-ingressgateway-customer-admin
-                topologyKey: kubernetes.io/hostname
-              weight: 100
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
                     - key: app.kubernetes.io/name
                       operator: In
                       values:
@@ -120,6 +111,14 @@ spec:
                   - services
                 topologyKey: kubernetes.io/hostname
               weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - istio-ingressgateway-customer-admin
+              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - proxy

--- a/kubernetes/cray-istio/tests/kuttl/deployment/01-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/01-assert.yaml
@@ -92,15 +92,6 @@ spec:
             - podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - istio-ingressgateway-customer-user
-                topologyKey: kubernetes.io/hostname
-              weight: 100
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
                     - key: app.kubernetes.io/name
                       operator: In
                       values:
@@ -120,6 +111,14 @@ spec:
                   - services
                 topologyKey: kubernetes.io/hostname
               weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - istio-ingressgateway-customer-user
+              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - proxy

--- a/kubernetes/cray-istio/tests/kuttl/deployment/02-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/02-assert.yaml
@@ -91,15 +91,6 @@ spec:
             - podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - istio-ingressgateway-hmn
-                topologyKey: kubernetes.io/hostname
-              weight: 100
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
                     - key: app.kubernetes.io/name
                       operator: In
                       values:
@@ -119,6 +110,14 @@ spec:
                   - services
                 topologyKey: kubernetes.io/hostname
               weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - istio-ingressgateway-hmn
+              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - proxy

--- a/kubernetes/cray-istio/tests/kuttl/deployment/03-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/03-assert.yaml
@@ -99,15 +99,6 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - istio-ingressgateway
-              topologyKey: kubernetes.io/hostname
-            weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
                 - key: app.kubernetes.io/name
                   operator: In
                   values:
@@ -127,6 +118,14 @@ spec:
               - services
               topologyKey: kubernetes.io/hostname
             weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - istio-ingressgateway
+              topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - proxy

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -67,11 +67,12 @@ deployments:
       name: tls-spire
     - port: 8888
       name: cloudinit
-    podAffinityTerm:
+    podAntiAffinity:
     - key: app
       operator: In
       values: istio-ingressgateway
       topologyKey: "kubernetes.io/hostname"
+    podAffinityTerm:
     - key: app.kubernetes.io/name
       operator: In
       values: cray-smd
@@ -114,11 +115,12 @@ deployments:
       limits:
         cpu: "20"
         memory: 1024Mi
-    podAffinityTerm:
+    podAntiAffinity:
     - key: app
       operator: In
       values: istio-ingressgateway-customer-admin
       topologyKey: "kubernetes.io/hostname"
+    podAffinityTerm:
     - key: app.kubernetes.io/name
       operator: In
       values: cray-smd
@@ -155,11 +157,12 @@ deployments:
     autoscaleEnabled: true
     autoscaleMin: 3
     autoscaleMax: 6
-    podAffinityTerm:
+    podAntiAffinity:
     - key: app
       operator: In
       values: istio-ingressgateway-customer-user
       topologyKey: "kubernetes.io/hostname"
+    podAffinityTerm:
     - key: app.kubernetes.io/name
       operator: In
       values: cray-smd
@@ -207,11 +210,12 @@ deployments:
     autoscaleMax: 6
     rollingMaxSurge: 100%
     rollingMaxUnavailable: 25%
-    podAffinityTerm:
+    podAntiAffinity:
     - key: app
       operator: In
       values: istio-ingressgateway-hmn
       topologyKey: "kubernetes.io/hostname"
+    podAffinityTerm:
     - key: app.kubernetes.io/name
       operator: In
       values: cray-smd


### PR DESCRIPTION
## Summary and Scope

Enable requiredDuringSchedulingIgnoredDuringExecution to prevent multiple ingress gateway pods from starting on the same worker, causing downtime when that worker gets restarted.

## Issues and Related PRs

* Resolves [CASMINST-4742](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4742)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that the proper requiredDuringSchedulingIgnoredDuringExecution were configured on pods.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

