### PR TITLE
CASMPET-5621: increase istiod default & min replica count

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.27.1
+version: 1.27.2
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
 keywords:

--- a/kubernetes/cray-istio-deploy/templates/istiooperator.yaml
+++ b/kubernetes/cray-istio-deploy/templates/istiooperator.yaml
@@ -40,6 +40,8 @@ spec:
         env:
         - name: ENABLE_LEGACY_FSGROUP_INJECTION
           value: "false"
+        # Recommended to be >1 in production
+        replicaCount: 3
         resources:
           requests:
             {{- if .Values.pilot.resources.requests.cpu }}
@@ -48,6 +50,13 @@ spec:
             {{- if .Values.pilot.resources.requests.memory }}
             memory: {{ .Values.pilot.resources.requests.memory }}
             {{- end }}
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 1
+        hpaSpec:
+          maxReplicas: 8
+          minReplicas: 3
       hub: {{ .Values.pilot.hub }}
       tag: {{ .Values.pilot.tag }}
   addonComponents:

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 2.6.2
+version: 2.6.3
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/templates/ingress-gateway/poddisruptionbudget.yaml
+++ b/kubernetes/cray-istio/templates/ingress-gateway/poddisruptionbudget.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.global.defaultPodDisruptionBudget.enabled }}
 {{- range $name, $options:= .Values.deployments }}
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $name }}


### PR DESCRIPTION
## Summary and Scope

Increased istiod replica count from 1 to 3, and adjusted its hpa autoscale range to be 3 (min) to 8 (max), as well as maxUnavailable to 1 (default is 25%). Chart patch versions were bumped.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5621](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5621)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

Upgraded the cray-istio charts, and verified istiod with 3 pods by default, and hpa setting is now set to the range of 3 to 8.  

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

