### PR TITLE
CASMPET-5796: upgrade to istio 1.10.6

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.27.2
+version: 1.28.0
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
 keywords:
@@ -32,15 +32,15 @@ sources:
   - https://github.com/Cray-HPE/cray-istio
 maintainers:
   - name: bo-quan
-appVersion: 1.9.9
+appVersion: 1.10.6
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: istio-pilot-distro
-      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.9.9-cray1-distroless
+      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.10.6-cray1-distroless
     - name: istio-pilot-distroless
-      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.9.9-cray1
+      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.10.6-cray1
     - name: istio-proxy-distro
-      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
+      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
     - name: istio-proxy-distroless
-      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1
+      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1

--- a/kubernetes/cray-istio-deploy/tests/istiooperator_test.yaml
+++ b/kubernetes/cray-istio-deploy/tests/istiooperator_test.yaml
@@ -37,10 +37,10 @@ tests:
           value: artifactory.algol60.net/csm-docker/stable/istio
       - equal:
           path: spec.components.pilot.tag
-          value: 1.9.9-cray1-distroless
+          value: 1.10.6-cray1-distroless
       - equal:
           path: spec.hub
           value: artifactory.algol60.net/csm-docker/stable/istio
       - equal:
           path: spec.tag
-          value: 1.9.9-cray1-distroless
+          value: 1.10.6-cray1-distroless

--- a/kubernetes/cray-istio-deploy/values.yaml
+++ b/kubernetes/cray-istio-deploy/values.yaml
@@ -23,7 +23,7 @@
 #
 ---
 hub: artifactory.algol60.net/csm-docker/stable/istio
-tag: 1.9.9-cray1-distroless   # Also update the proxyv2 annotations in Chart.yaml
+tag: 1.10.6-cray1-distroless   # Also update the proxyv2 annotations in Chart.yaml
 
 kubectl:
   image:
@@ -32,7 +32,7 @@ kubectl:
 
 pilot:
   hub: artifactory.algol60.net/csm-docker/stable/istio
-  tag: 1.9.9-cray1-distroless   # Also update the pilot annotations in Chart.yaml
+  tag: 1.10.6-cray1-distroless   # Also update the pilot annotations in Chart.yaml
   resources:
     requests:
       cpu:

--- a/kubernetes/cray-istio-operator/Chart.yaml
+++ b/kubernetes/cray-istio-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.24.0
+version: 1.25.0
 name: cray-istio-operator
 description: Helm chart for deploying Istio operator
 keywords:
@@ -33,14 +33,14 @@ sources:
   - https://github.com/Cray-HPE/cray-istio
 dependencies:
   - name: istio-operator
-    version: 1.7.0
+    version: 1.10.6
 maintainers:
   - name: bo-quan
-appVersion: 1.9.9
+appVersion: 1.10.6
 annotations:
   artifacthub.io/images: |
     - name: istio-operator-distroless
-      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.9.9-cray1-distroless
+      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.10.6-cray1-distroless
     - name: istio-operator-distro
-      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.9.9-cray1
+      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.10.6-cray1
   artifacthub.io/license: MIT

--- a/kubernetes/cray-istio-operator/README.md
+++ b/kubernetes/cray-istio-operator/README.md
@@ -1,6 +1,6 @@
 
 This deploys the Istio operator. There are instructions here:
-https://istio.io/v1.9/docs/setup/install/operator/
+https://istio.io/v1.10/docs/setup/install/operator/
 
 The istio-operator chart in the charts/ directory was copied (and modified -- see
 details below) from the istio release which is available for download at

--- a/kubernetes/cray-istio-operator/charts/istio-operator/Chart.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio-operator
-version: 1.7.0
+version: 1.10.6
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio operator
 keywords:

--- a/kubernetes/cray-istio-operator/charts/istio-operator/crds/crd-operator.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/crds/crd-operator.yaml
@@ -1,46 +1,48 @@
 # SYNC WITH manifests/charts/base/files
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: istiooperators.install.istio.io
+  labels:
+    release: istio
 spec:
+  conversion:
+    strategy: None
   group: install.istio.io
   names:
     kind: IstioOperator
+    listKind: IstioOperatorList
     plural: istiooperators
     singular: istiooperator
     shortNames:
     - iop
+    - io
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        spec:
-          description: 'Specification of the desired state of the istio control plane resource.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
-        status:
-          description: 'Status describes each of istio control plane component status at the current time.
-            0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING.
-            More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html &
-            https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Istio control plane revision
+      jsonPath: .spec.revision
+      name: Revision
+      type: string
+    - description: IOP current state
+      jsonPath: .status.status
+      name: Status
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---

--- a/kubernetes/cray-istio-operator/charts/istio-operator/files/gen-operator.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/files/gen-operator.yaml
@@ -181,7 +181,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: gcr.io/istio-testing/operator:1.9-dev
+          image: gcr.io/istio-testing/operator:1.10-dev
           command:
           - operator
           - server

--- a/kubernetes/cray-istio-operator/charts/istio-operator/templates/deployment.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/templates/deployment.yaml
@@ -14,9 +14,9 @@ spec:
         name: istio-operator
     spec:
       serviceAccountName: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-{{- if .Values.operator.priorityClassName }}
+    {{- if .Values.operator.priorityClassName }}
       priorityClassName: "{{ .Values.operator.priorityClassName }}"
-{{- end }}
+    {{- end }}
       containers:
         - name: istio-operator
           image: {{.Values.hub}}/operator:{{.Values.tag}}

--- a/kubernetes/cray-istio-operator/charts/istio-operator/values.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/values.yaml
@@ -1,5 +1,5 @@
-hub: gcr.io/istio-testing
-tag: latest
+hub: docker.io/istio
+tag: 1.10.6
 
 # ImagePullSecrets for operator ServiceAccount, list of secrets in the same namespace
 # used to pull operator image. Must be set for any cluster configured with private docker registry.

--- a/kubernetes/cray-istio-operator/tests/deployment_test.yaml
+++ b/kubernetes/cray-istio-operator/tests/deployment_test.yaml
@@ -34,4 +34,4 @@ tests:
           pattern: istio-operator$
       - equal:
           path: spec.template.spec.containers[0].image
-          value: artifactory.algol60.net/csm-docker/stable/istio/operator:1.9.9-cray1-distroless
+          value: artifactory.algol60.net/csm-docker/stable/istio/operator:1.10.6-cray1-distroless

--- a/kubernetes/cray-istio-operator/values.yaml
+++ b/kubernetes/cray-istio-operator/values.yaml
@@ -23,7 +23,7 @@
 #
 istio-operator:
   hub: artifactory.algol60.net/csm-docker/stable/istio
-  tag: 1.9.9-cray1-distroless  # Also update the annotation in Chart.yaml
+  tag: 1.10.6-cray1-distroless  # Also update the annotation in Chart.yaml
 
 kubectl:
   image:

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 2.6.3
+version: 2.7.0
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:
@@ -32,6 +32,6 @@ sources:
   - https://github.com/Cray-HPE/cray-istio
 maintainers:
   - name: bo-quan
-appVersion: 1.9.9
+appVersion: 1.10.6
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-istio/templates/ingress-gateway/poddisruptionbudget.yaml
+++ b/kubernetes/cray-istio/templates/ingress-gateway/poddisruptionbudget.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.global.defaultPodDisruptionBudget.enabled }}
 {{- range $name, $options:= .Values.deployments }}
 ---
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $name }}

--- a/kubernetes/cray-istio/tests/kuttl/deployment/00-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/00-assert.yaml
@@ -190,7 +190,7 @@ spec:
               value: sni-dnat
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
+          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:

--- a/kubernetes/cray-istio/tests/kuttl/deployment/01-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/01-assert.yaml
@@ -190,7 +190,7 @@ spec:
               value: sni-dnat
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
+          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:

--- a/kubernetes/cray-istio/tests/kuttl/deployment/02-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/02-assert.yaml
@@ -189,7 +189,7 @@ spec:
               value: sni-dnat
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
+          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:

--- a/kubernetes/cray-istio/tests/kuttl/deployment/03-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/03-assert.yaml
@@ -197,7 +197,7 @@ spec:
           value: sni-dnat
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
+        image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -509,7 +509,7 @@ global:
   hub: artifactory.algol60.net/csm-docker/stable/istio
 
   # Default tag for Istio images.
-  tag: 1.9.9-cray1-distroless
+  tag: 1.10.6-cray1-distroless
 
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components


### PR DESCRIPTION
## Summary and Scope

Upgrade to istio 1.10.6. Bumped the minor versions of cray-istio, cray-istio-deploy, and cray-istio-operator charts.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5796](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5796)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

In both vshasta and mug systems, upgraded the istio charts to use the new v1.10.6 images (as well as latest opa envoy plugin & kiali v1.36.7)and validated the following:
* capmc api call still works with an admin token
* kiali & grafana UIs still work and show the correct component versions
* can still log into keycloak UIs (after restarting keycloak-postgres & cray-keycloak statefulsets to run the new envoy sidecar for them) and create clients & users

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

