### PR TITLE
Casm 3619

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.28.0
+version: 1.29.0
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
 keywords:
@@ -32,15 +32,15 @@ sources:
   - https://github.com/Cray-HPE/cray-istio
 maintainers:
   - name: bo-quan
-appVersion: 1.10.6
+appVersion: 1.11.8
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: istio-pilot-distro
-      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.10.6-cray1-distroless
+      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1-distroless
     - name: istio-pilot-distroless
-      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.10.6-cray1
+      image: artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1
     - name: istio-proxy-distro
-      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
+      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.11.8-cray1-distroless
     - name: istio-proxy-distroless
-      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1
+      image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.11.8-cray1

--- a/kubernetes/cray-istio-deploy/tests/istiooperator_test.yaml
+++ b/kubernetes/cray-istio-deploy/tests/istiooperator_test.yaml
@@ -37,10 +37,10 @@ tests:
           value: artifactory.algol60.net/csm-docker/stable/istio
       - equal:
           path: spec.components.pilot.tag
-          value: 1.10.6-cray1-distroless
+          value: 1.11.8-cray1-distroless
       - equal:
           path: spec.hub
           value: artifactory.algol60.net/csm-docker/stable/istio
       - equal:
           path: spec.tag
-          value: 1.10.6-cray1-distroless
+          value: 1.11.8-cray1-distroless

--- a/kubernetes/cray-istio-deploy/values.yaml
+++ b/kubernetes/cray-istio-deploy/values.yaml
@@ -23,7 +23,7 @@
 #
 ---
 hub: artifactory.algol60.net/csm-docker/stable/istio
-tag: 1.10.6-cray1-distroless   # Also update the proxyv2 annotations in Chart.yaml
+tag: 1.11.8-cray1-distroless   # Also update the proxyv2 annotations in Chart.yaml
 
 kubectl:
   image:
@@ -32,7 +32,7 @@ kubectl:
 
 pilot:
   hub: artifactory.algol60.net/csm-docker/stable/istio
-  tag: 1.10.6-cray1-distroless   # Also update the pilot annotations in Chart.yaml
+  tag: 1.11.8-cray1-distroless   # Also update the pilot annotations in Chart.yaml
   resources:
     requests:
       cpu:
@@ -63,9 +63,9 @@ istio:
       autoscaleMin: 2
       autoscaleMax: 5
       ports:
-      - port: 80
+      - port: 8080
         name: http2
-      - port: 443
+      - port: 8443
         name: https
       env:
         ISTIO_META_IDLE_TIMEOUT: 10m

--- a/kubernetes/cray-istio-deploy/values.yaml
+++ b/kubernetes/cray-istio-deploy/values.yaml
@@ -63,10 +63,14 @@ istio:
       autoscaleMin: 2
       autoscaleMax: 5
       ports:
-      - port: 8080
+      - port: 80
         name: http2
-      - port: 8443
+        protocol: TCP
+        targetPort: 8080
+      - port: 443
         name: https
+        protocol: TCP
+        targetPort: 8443
       env:
         ISTIO_META_IDLE_TIMEOUT: 10m
 

--- a/kubernetes/cray-istio-operator/Chart.yaml
+++ b/kubernetes/cray-istio-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.25.0
+version: 1.26.0
 name: cray-istio-operator
 description: Helm chart for deploying Istio operator
 keywords:
@@ -33,14 +33,14 @@ sources:
   - https://github.com/Cray-HPE/cray-istio
 dependencies:
   - name: istio-operator
-    version: 1.10.6
+    version: 1.11.8
 maintainers:
   - name: bo-quan
-appVersion: 1.10.6
+appVersion: 1.11.8
 annotations:
   artifacthub.io/images: |
     - name: istio-operator-distroless
-      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.10.6-cray1-distroless
+      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1-distroless
     - name: istio-operator-distro
-      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.10.6-cray1
+      image: artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1
   artifacthub.io/license: MIT

--- a/kubernetes/cray-istio-operator/README.md
+++ b/kubernetes/cray-istio-operator/README.md
@@ -1,6 +1,6 @@
 
 This deploys the Istio operator. There are instructions here:
-https://istio.io/v1.10/docs/setup/install/operator/
+https://istio.io/v1.11/docs/setup/install/operator/
 
 The istio-operator chart in the charts/ directory was copied (and modified -- see
 details below) from the istio release which is available for download at

--- a/kubernetes/cray-istio-operator/charts/istio-operator/Chart.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio-operator
-version: 1.10.6
+version: 1.11.8
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio operator
 keywords:

--- a/kubernetes/cray-istio-operator/charts/istio-operator/files/gen-operator.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/files/gen-operator.yaml
@@ -124,6 +124,7 @@ rules:
   - namespaces
   - pods
   - pods/proxy
+  - pods/portforward
   - persistentvolumeclaims
   - secrets
   - services
@@ -181,7 +182,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: gcr.io/istio-testing/operator:1.10-dev
+          image: gcr.io/istio-testing/operator:1.11-dev
           command:
           - operator
           - server

--- a/kubernetes/cray-istio-operator/charts/istio-operator/templates/clusterrole.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/templates/clusterrole.yaml
@@ -106,6 +106,7 @@ rules:
   - namespaces
   - pods
   - pods/proxy
+  - pods/portforward
   - persistentvolumeclaims
   - secrets
   - services

--- a/kubernetes/cray-istio-operator/charts/istio-operator/values.yaml
+++ b/kubernetes/cray-istio-operator/charts/istio-operator/values.yaml
@@ -1,5 +1,5 @@
 hub: docker.io/istio
-tag: 1.10.6
+tag: 1.11.8
 
 # ImagePullSecrets for operator ServiceAccount, list of secrets in the same namespace
 # used to pull operator image. Must be set for any cluster configured with private docker registry.
@@ -27,4 +27,3 @@ operator:
     requests:
       cpu: 50m
       memory: 128Mi
-

--- a/kubernetes/cray-istio-operator/tests/deployment_test.yaml
+++ b/kubernetes/cray-istio-operator/tests/deployment_test.yaml
@@ -34,4 +34,4 @@ tests:
           pattern: istio-operator$
       - equal:
           path: spec.template.spec.containers[0].image
-          value: artifactory.algol60.net/csm-docker/stable/istio/operator:1.10.6-cray1-distroless
+          value: artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1-distroless

--- a/kubernetes/cray-istio-operator/values.yaml
+++ b/kubernetes/cray-istio-operator/values.yaml
@@ -23,7 +23,7 @@
 #
 istio-operator:
   hub: artifactory.algol60.net/csm-docker/stable/istio
-  tag: 1.10.6-cray1-distroless  # Also update the annotation in Chart.yaml
+  tag: 1.11.8-cray1-distroless  # Also update the annotation in Chart.yaml
 
 kubectl:
   image:

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 2.7.0
+version: 2.8.0
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:
@@ -32,6 +32,6 @@ sources:
   - https://github.com/Cray-HPE/cray-istio
 maintainers:
   - name: bo-quan
-appVersion: 1.10.6
+appVersion: 1.11.8
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-istio/templates/ingress-gateway/meshexpansion.yaml
+++ b/kubernetes/cray-istio/templates/ingress-gateway/meshexpansion.yaml
@@ -50,7 +50,7 @@ spec:
     - destination:
         host: istiod.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
         port:
-          number: 8443
+          number: 443
 ---
 
 apiVersion: networking.istio.io/v1alpha3

--- a/kubernetes/cray-istio/templates/ingress-gateway/meshexpansion.yaml
+++ b/kubernetes/cray-istio/templates/ingress-gateway/meshexpansion.yaml
@@ -50,7 +50,7 @@ spec:
     - destination:
         host: istiod.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
         port:
-          number: 443
+          number: 8443
 ---
 
 apiVersion: networking.istio.io/v1alpha3

--- a/kubernetes/cray-istio/tests/kuttl/deployment/00-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/00-assert.yaml
@@ -190,13 +190,13 @@ spec:
               value: sni-dnat
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
+          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.11.8-cray1-distroless
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
-            - containerPort: 443
+            - containerPort: 8443
               protocol: TCP
             - containerPort: 15090
               name: http-envoy-prom

--- a/kubernetes/cray-istio/tests/kuttl/deployment/01-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/01-assert.yaml
@@ -190,13 +190,13 @@ spec:
               value: sni-dnat
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
+          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.11.8-cray1-distroless
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
-            - containerPort: 443
+            - containerPort: 8443
               protocol: TCP
             - containerPort: 15090
               name: http-envoy-prom

--- a/kubernetes/cray-istio/tests/kuttl/deployment/02-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/02-assert.yaml
@@ -189,13 +189,13 @@ spec:
               value: sni-dnat
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
+          image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.11.8-cray1-distroless
           imagePullPolicy: IfNotPresent
           name: istio-proxy
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
-            - containerPort: 443
+            - containerPort: 8443
               protocol: TCP
             - containerPort: 8888
               protocol: TCP

--- a/kubernetes/cray-istio/tests/kuttl/deployment/03-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/deployment/03-assert.yaml
@@ -197,13 +197,13 @@ spec:
           value: sni-dnat
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
+        image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.11.8-cray1-distroless
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           protocol: TCP
-        - containerPort: 443
+        - containerPort: 8443
           protocol: TCP
         - containerPort: 8081
           protocol: TCP

--- a/kubernetes/cray-istio/tests/kuttl/gateways/00-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/gateways/00-assert.yaml
@@ -39,15 +39,15 @@ spec:
     - '*'
     port:
       name: http
-      number: 8080
+      number: 80
       protocol: HTTP
     tls:
       httpsRedirect: true
   - hosts:
     - '*'
     port:
-      name: https-8443
-      number: 8443
+      name: https-443
+      number: 443
       protocol: HTTPS
     tls:
       credentialName: ingress-gateway-cert

--- a/kubernetes/cray-istio/tests/kuttl/gateways/00-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/gateways/00-assert.yaml
@@ -39,15 +39,15 @@ spec:
     - '*'
     port:
       name: http
-      number: 80
+      number: 8080
       protocol: HTTP
     tls:
       httpsRedirect: true
   - hosts:
     - '*'
     port:
-      name: https-443
-      number: 443
+      name: https-8443
+      number: 8443
       protocol: HTTPS
     tls:
       credentialName: ingress-gateway-cert

--- a/kubernetes/cray-istio/tests/kuttl/gateways/01-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/gateways/01-assert.yaml
@@ -39,13 +39,13 @@ spec:
     - '*'
     port:
       name: http
-      number: 80
+      number: 8080
       protocol: HTTP
   - hosts:
     - '*'
     port:
-      name: https-443
-      number: 443
+      name: https-8443
+      number: 8443
       protocol: HTTPS
     tls:
       credentialName: ingress-gateway-cert

--- a/kubernetes/cray-istio/tests/kuttl/gateways/02-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/gateways/02-assert.yaml
@@ -39,13 +39,13 @@ spec:
     - '*'
     port:
       name: http
-      number: 80
+      number: 8080
       protocol: HTTP
   - hosts:
     - '*'
     port:
-      name: https-443
-      number: 443
+      name: https-8443
+      number: 8443
       protocol: HTTPS
     tls:
       credentialName: ingress-gateway-cert

--- a/kubernetes/cray-istio/tests/kuttl/gateways/02-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/gateways/02-assert.yaml
@@ -39,13 +39,13 @@ spec:
     - '*'
     port:
       name: http
-      number: 8080
+      number: 80
       protocol: HTTP
   - hosts:
     - '*'
     port:
-      name: https-8443
-      number: 8443
+      name: https-443
+      number: 443
       protocol: HTTPS
     tls:
       credentialName: ingress-gateway-cert

--- a/kubernetes/cray-istio/tests/kuttl/gateways/03-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/gateways/03-assert.yaml
@@ -39,13 +39,13 @@ spec:
     - '*'
     port:
       name: http
-      number: 80
+      number: 8080
       protocol: HTTP
   - hosts:
     - '*'
     port:
-      name: https-443
-      number: 443
+      name: https-8443
+      number: 8443
       protocol: HTTPS
     tls:
       credentialName: ingress-gateway-cert

--- a/kubernetes/cray-istio/tests/kuttl/gateways/03-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/gateways/03-assert.yaml
@@ -39,13 +39,13 @@ spec:
     - '*'
     port:
       name: http
-      number: 8080
+      number: 80
       protocol: HTTP
   - hosts:
     - '*'
     port:
-      name: https-8443
-      number: 8443
+      name: https-443
+      number: 443
       protocol: HTTPS
     tls:
       credentialName: ingress-gateway-cert

--- a/kubernetes/cray-istio/tests/kuttl/services/00-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/00-assert.yaml
@@ -38,11 +38,11 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 8080
+    port: 80
     protocol: TCP
     targetPort: 8080
   - name: https
-    port: 8443
+    port: 443
     protocol: TCP
     targetPort: 8443
   selector:

--- a/kubernetes/cray-istio/tests/kuttl/services/00-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/00-assert.yaml
@@ -38,13 +38,13 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 80
+    port: 8080
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   - name: https
-    port: 443
+    port: 8443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
   selector:
     app: istio-ingressgateway-customer-user
     istio: ingressgateway-customer-user

--- a/kubernetes/cray-istio/tests/kuttl/services/01-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/01-assert.yaml
@@ -38,11 +38,11 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 8080
+    port: 80
     protocol: TCP
     targetPort: 8080
   - name: https
-    port: 8443
+    port: 443
     protocol: TCP
     targetPort: 8443
   selector:

--- a/kubernetes/cray-istio/tests/kuttl/services/01-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/01-assert.yaml
@@ -38,13 +38,13 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 80
+    port: 8080
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   - name: https
-    port: 443
+    port: 8443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
   selector:
     app: istio-ingressgateway
     istio: ingressgateway

--- a/kubernetes/cray-istio/tests/kuttl/services/02-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/02-assert.yaml
@@ -38,11 +38,11 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 8080
+    port: 80
     protocol: TCP
     targetPort: 8080
   - name: https
-    port: 8443
+    port: 443
     protocol: TCP
     targetPort: 8443
   - name: cloudinit

--- a/kubernetes/cray-istio/tests/kuttl/services/02-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/02-assert.yaml
@@ -38,13 +38,13 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 80
+    port: 8080
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   - name: https
-    port: 443
+    port: 8443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
   - name: cloudinit
     port: 8888
     protocol: TCP

--- a/kubernetes/cray-istio/tests/kuttl/services/03-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/03-assert.yaml
@@ -37,13 +37,13 @@ spec:
   externalTrafficPolicy: Local
   ports:
   - name: http2
-    port: 80
+    port: 8080
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   - name: https
-    port: 443
+    port: 8443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
   - name: tls-spire
     port: 8081
     protocol: TCP

--- a/kubernetes/cray-istio/tests/kuttl/services/03-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/03-assert.yaml
@@ -37,11 +37,11 @@ spec:
   externalTrafficPolicy: Local
   ports:
   - name: http2
-    port: 8080
+    port: 80
     protocol: TCP
     targetPort: 8080
   - name: https
-    port: 8443
+    port: 443
     protocol: TCP
     targetPort: 8443
   - name: tls-spire

--- a/kubernetes/cray-istio/tests/kuttl/services/04-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/04-assert.yaml
@@ -38,11 +38,11 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 8080
+    port: 80
     protocol: TCP
     targetPort: 8080
   - name: https
-    port: 8443
+    port: 443
     protocol: TCP
     targetPort: 8443
   selector:

--- a/kubernetes/cray-istio/tests/kuttl/services/04-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/04-assert.yaml
@@ -38,13 +38,13 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 80
+    port: 8080
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   - name: https
-    port: 443
+    port: 8443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
   selector:
     app: istio-ingressgateway-customer-user
     istio: ingressgateway-customer-user

--- a/kubernetes/cray-istio/tests/kuttl/services/05-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/05-assert.yaml
@@ -37,11 +37,11 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 8080
+    port: 80
     protocol: TCP
     targetPort: 8080
   - name: https
-    port: 8443
+    port: 443
     protocol: TCP
     targetPort: 8443
   - name: tls-spire

--- a/kubernetes/cray-istio/tests/kuttl/services/05-assert.yaml
+++ b/kubernetes/cray-istio/tests/kuttl/services/05-assert.yaml
@@ -37,13 +37,13 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
   - name: http2
-    port: 80
+    port: 8080
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   - name: https
-    port: 443
+    port: 8443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
   - name: tls-spire
     port: 8081
     protocol: TCP

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -59,9 +59,9 @@ deployments:
       targetAverageUtilization: 80
     applicationPorts: "80"
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
     - port: 8081
       name: tls-spire
@@ -124,9 +124,9 @@ deployments:
     cpu:
       targetAverageUtilization: 80
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
     env:
       ISTIO_META_ROUTER_MODE: "sni-dnat"
@@ -170,9 +170,9 @@ deployments:
     cpu:
       targetAverageUtilization: 80
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
     env:
       ISTIO_META_ROUTER_MODE: "sni-dnat"
@@ -231,9 +231,9 @@ deployments:
       mountPath: /etc/istio/ingressgateway-ca-certs
     applicationPorts: "80"
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
     - port: 8888
       name: cloudinit
@@ -254,15 +254,15 @@ gateways:
         - '*'
         port:
           name: http
-          number: 80
+          number: 8080
           protocol: HTTP
         tls:
           httpsRedirect: true
       - hosts:
         - '*'
         port:
-          name: https-443
-          number: 443
+          name: https-8443
+          number: 8443
           protocol: HTTPS
         tls:
           credentialName: ingress-gateway-cert
@@ -293,13 +293,13 @@ gateways:
         - '*'
         port:
           name: http
-          number: 80
+          number: 8080
           protocol: HTTP
       - hosts:
         - '*'
         port:
-          name: https-443
-          number: 443
+          name: https-8443
+          number: 8443
           protocol: HTTPS
         tls:
           credentialName: ingress-gateway-cert
@@ -322,13 +322,13 @@ gateways:
         - '*'
         port:
           name: http
-          number: 80
+          number: 8080
           protocol: HTTP
       - hosts:
         - '*'
         port:
-          name: https-443
-          number: 443
+          name: https-8443
+          number: 8443
           protocol: HTTPS
         tls:
           credentialName: ingress-gateway-cert
@@ -345,13 +345,13 @@ gateways:
         - '*'
         port:
           name: http
-          number: 80
+          number: 8080
           protocol: HTTP
       - hosts:
         - '*'
         port:
-          name: https-443
-          number: 443
+          name: https-8443
+          number: 8443
           protocol: HTTPS
         tls:
           credentialName: ingress-gateway-cert
@@ -369,9 +369,9 @@ services:
     externalTrafficPolicy: "Cluster"
     type: LoadBalancer
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
     - port: 8081
       name: tls-spire
@@ -388,9 +388,9 @@ services:
     externalTrafficPolicy: "Local"
     type: LoadBalancer
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
     - port: 8081
       name: tls-spire
@@ -411,9 +411,9 @@ services:
       metallb.universe.tf/address-pool: hardware-management
       external-dns.alpha.kubernetes.io/hostname: shasta.local,auth.local
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
     - port: 8888
       name: cloudinit
@@ -431,9 +431,9 @@ services:
       metallb.universe.tf/address-pool: customer-high-speed
       external-dns.alpha.kubernetes.io/hostname: shasta.local,auth.local
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
   istio-ingressgateway-chn:
     selectors:
@@ -448,9 +448,9 @@ services:
       metallb.universe.tf/address-pool: customer-high-speed
     externalTrafficPolicy: "Cluster"
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
   istio-ingressgateway-cmn:
     selectors:
@@ -465,9 +465,9 @@ services:
       metallb.universe.tf/address-pool: customer-access
     externalTrafficPolicy: "Cluster"
     ports:
-    - port: 80
+    - port: 8080
       name: http2
-    - port: 443
+    - port: 8443
       name: https
 
 servicesGateway:
@@ -480,7 +480,7 @@ servicesGateway:
     hosts:
       - "*"
   # Note: This is only needed to provide an HTTP only port with no redirects.
-  # Once cloud-init can use HTTPS, remove this port (8888) and use port 443.
+  # Once cloud-init can use HTTPS, remove this port (8888) and use port 8443.
   cloudinit:
     enabled: true
     hosts:
@@ -509,7 +509,7 @@ global:
   hub: artifactory.algol60.net/csm-docker/stable/istio
 
   # Default tag for Istio images.
-  tag: 1.10.6-cray1-distroless
+  tag: 1.11.8-cray1-distroless
 
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -59,10 +59,12 @@ deployments:
       targetAverageUtilization: 80
     applicationPorts: "80"
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
     - port: 8081
       name: tls-spire
     - port: 8888
@@ -124,10 +126,12 @@ deployments:
     cpu:
       targetAverageUtilization: 80
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
     env:
       ISTIO_META_ROUTER_MODE: "sni-dnat"
       ISTIO_META_IDLE_TIMEOUT: 10m
@@ -170,10 +174,12 @@ deployments:
     cpu:
       targetAverageUtilization: 80
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
     env:
       ISTIO_META_ROUTER_MODE: "sni-dnat"
       ISTIO_META_IDLE_TIMEOUT: 10m
@@ -231,10 +237,12 @@ deployments:
       mountPath: /etc/istio/ingressgateway-ca-certs
     applicationPorts: "80"
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
     - port: 8888
       name: cloudinit
     env:
@@ -254,15 +262,15 @@ gateways:
         - '*'
         port:
           name: http
-          number: 8080
+          number: 80
           protocol: HTTP
         tls:
           httpsRedirect: true
       - hosts:
         - '*'
         port:
-          name: https-8443
-          number: 8443
+          name: https-443
+          number: 443
           protocol: HTTPS
         tls:
           credentialName: ingress-gateway-cert
@@ -293,13 +301,12 @@ gateways:
         - '*'
         port:
           name: http
-          number: 8080
-          protocol: HTTP
+          number: 80
       - hosts:
         - '*'
         port:
-          name: https-8443
-          number: 8443
+          name: https-443
+          number: 443
           protocol: HTTPS
         tls:
           credentialName: ingress-gateway-cert
@@ -322,13 +329,13 @@ gateways:
         - '*'
         port:
           name: http
-          number: 8080
+          number: 80
           protocol: HTTP
       - hosts:
         - '*'
         port:
-          name: https-8443
-          number: 8443
+          name: https-443
+          number: 443
           protocol: HTTPS
         tls:
           credentialName: ingress-gateway-cert
@@ -345,13 +352,13 @@ gateways:
         - '*'
         port:
           name: http
-          number: 8080
+          number: 80
           protocol: HTTP
       - hosts:
         - '*'
         port:
-          name: https-8443
-          number: 8443
+          name: https-443
+          number: 443
           protocol: HTTPS
         tls:
           credentialName: ingress-gateway-cert
@@ -369,10 +376,12 @@ services:
     externalTrafficPolicy: "Cluster"
     type: LoadBalancer
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
     - port: 8081
       name: tls-spire
     - port: 8888
@@ -388,10 +397,12 @@ services:
     externalTrafficPolicy: "Local"
     type: LoadBalancer
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
     - port: 8081
       name: tls-spire
     - port: 8888
@@ -411,10 +422,12 @@ services:
       metallb.universe.tf/address-pool: hardware-management
       external-dns.alpha.kubernetes.io/hostname: shasta.local,auth.local
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
     - port: 8888
       name: cloudinit
   istio-ingressgateway-can:
@@ -431,10 +444,12 @@ services:
       metallb.universe.tf/address-pool: customer-high-speed
       external-dns.alpha.kubernetes.io/hostname: shasta.local,auth.local
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
   istio-ingressgateway-chn:
     selectors:
       app: istio-ingressgateway-customer-user
@@ -448,10 +463,12 @@ services:
       metallb.universe.tf/address-pool: customer-high-speed
     externalTrafficPolicy: "Cluster"
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
   istio-ingressgateway-cmn:
     selectors:
       app: istio-ingressgateway
@@ -465,10 +482,12 @@ services:
       metallb.universe.tf/address-pool: customer-access
     externalTrafficPolicy: "Cluster"
     ports:
-    - port: 8080
+    - port: 80
       name: http2
-    - port: 8443
+      targetPort: 8080
+    - port: 443
       name: https
+      targetPort: 8443
 
 servicesGateway:
   tls: true
@@ -480,7 +499,7 @@ servicesGateway:
     hosts:
       - "*"
   # Note: This is only needed to provide an HTTP only port with no redirects.
-  # Once cloud-init can use HTTPS, remove this port (8888) and use port 8443.
+  # Once cloud-init can use HTTPS, remove this port (8888) and use port 443.
   cloudinit:
     enabled: true
     hosts:


### PR DESCRIPTION
## Summary and Scope

Upgrade to istio 1.11.8. Changed http/https ports from 80/443 to 8080/8443 as ports below 1000 requires root privilege which will make the istio containers more vulnerable to attacks. Bumped the minor versions of cray-istio, cray-istio-deploy, and cray-istio-operator charts.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-3619](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3619)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`

### Test description:

Upgraded the istio charts to use the new v1.11.8 images as well as kiali v1.41.0 image, and validated kiali & grafana UIs still work and show the correct component versions.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

