### PR TITLE
CASMPET-6393 Add MQTT to istio gateway

### DIFF
--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 2.7.0
+version: 2.7.1
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/templates/certificate.yaml
+++ b/kubernetes/cray-istio/templates/certificate.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -22,6 +22,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- if and .Values.servicesGateway.tls }}
+---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
@@ -36,6 +37,27 @@ spec:
   renewBefore: 480h
   dnsNames:
 {{- range .Values.certificate.dnsNames }}
+     - "{{ . }}"
+{{- end }}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: dvs-mqtt-cert
+spec:
+  secretName: {{ .Values.mqttCertificate.secretName }}
+  issuerRef:
+    kind: Issuer
+    name: cert-manager-issuer-common
+  commonName: "{{ .Values.mqttCertificate.commonName }}"
+  duration: 8760h
+  renewBefore: 72h
+  dnsNames:
+{{- range .Values.mqttCertificate.dnsNames }}
+     - "{{ . }}"
+{{- end }}
+  ipAddresses:
+{{- range .Values.mqttCertificate.ipAddresses }}
      - "{{ . }}"
 {{- end }}
 {{- end }}

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,6 +35,15 @@ certificate:
     - "*.vshasta.io"
   secretName: ingress-gateway-cert
 
+mqttCertificate:
+    commonName: "dvs-mqtt.local"
+    dnsNames:
+      - "dvs-mqtt.local"
+    ipAddresses:
+      - "10.92.100.71"
+      - "10.92.100.81"
+    secretName: dvs-mqtt-cert
+
 deployments:
   istio-ingressgateway:
     labels:
@@ -65,6 +74,8 @@ deployments:
       name: https
     - port: 8081
       name: tls-spire
+    - port: 8883
+      name: mqtt-secure
     - port: 8888
       name: cloudinit
     podAffinityTerm:
@@ -278,6 +289,15 @@ gateways:
       - hosts:
         - '*'
         port:
+          number: 8883
+          name: mqtt-secure
+          protocol: TLS
+        tls:
+          mode: SIMPLE
+          credentialName: dvs-mqtt-cert
+      - hosts:
+        - '*'
+        port:
           name: cloudinit
           number: 8888
           protocol: HTTP
@@ -375,6 +395,8 @@ services:
       name: https
     - port: 8081
       name: tls-spire
+    - port: 8883
+      name: mqtt-secure
     - port: 8888
       name: cloudinit
   istio-ingressgateway-local:
@@ -394,6 +416,8 @@ services:
       name: https
     - port: 8081
       name: tls-spire
+    - port: 8883
+      name: mqtt-secure
     - port: 8888
       name: cloudinit
   istio-ingressgateway-hmn:

--- a/kubernetes/cray-istio/values.yaml
+++ b/kubernetes/cray-istio/values.yaml
@@ -36,13 +36,13 @@ certificate:
   secretName: ingress-gateway-cert
 
 mqttCertificate:
-    commonName: "dvs-mqtt.local"
-    dnsNames:
-      - "dvs-mqtt.local"
-    ipAddresses:
-      - "10.92.100.71"
-      - "10.92.100.81"
-    secretName: dvs-mqtt-cert
+  commonName: "dvs-mqtt.local"
+  dnsNames:
+    - "dvs-mqtt.local"
+  ipAddresses:
+    - "10.92.100.71"
+    - "10.92.100.81"
+  secretName: dvs-mqtt-cert
 
 deployments:
   istio-ingressgateway:


### PR DESCRIPTION
## Summary and Scope

This adds the MQTT broker to the ingress gateway and uses it to terminate TLS.

## Issues and Related PRs

* Resolves [CASMPET-6393](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6393)

## Testing


### Tested on:

  * groot

### Test description:

Validated certificates were added and that MQTT worked with this chart change.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
