### PR TITLE
CASMPET-6904 update certmanager apiVersion

### DIFF
--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 2.9.1
+version: 2.9.2
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 2.9.2
+version: 2.10.0
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/templates/certificate.yaml
+++ b/kubernetes/cray-istio/templates/certificate.yaml
@@ -23,7 +23,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- if and .Values.servicesGateway.tls }}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ingress-gateway-cert
@@ -40,7 +40,7 @@ spec:
      - "{{ . }}"
 {{- end }}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: dvs-mqtt-cert


### PR DESCRIPTION
## Summary and Scope

Update cert-manager api version from v1alpha2 to v1. This is necessary for the cert-manager upgrade to v1.12.9 that is happening in CSM 1.6.

## Issues and Related PRs

* Relates to [CASMPET-6904](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6904)

## Testing

### Tested on:

  * Beau

### Test description:

Upgraded the cray-istio chart.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

