### PR TITLE
CASMPET-6346: reduce istio tracing dns traffic

### DIFF
--- a/kubernetes/cray-istio-deploy/Chart.yaml
+++ b/kubernetes/cray-istio-deploy/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 2.0.0
+version: 2.0.1
 name: cray-istio-deploy
 description: Creates the IstioOperator instance that deploys the Istio control plane.
 keywords:

--- a/kubernetes/cray-istio-deploy/values.yaml
+++ b/kubernetes/cray-istio-deploy/values.yaml
@@ -42,6 +42,9 @@ meshConfig:
   accessLogFile: /dev/stdout
   defaultConfig:
     holdApplicationUntilProxyStarts: true
+    tracing:
+      zipkin:
+        address: zipkin.istio-system.svc.cluster.local:9411
 
 istio:
 


### PR DESCRIPTION
## Summary and Scope

We're not using istio tracing but it is enabled by default, with zipkin.istio-system as the FQDN. With the default setting, CoreDNS can't answer the query so sends it to Unbound which also can't answer it so forwards it to the customer DNS server, causing a lot of DNS traffic. Since there is an upstream bug that prevents us from disabling istio tracing completely, this PR changes the FQDN to zipkin.istio-system.svc.cluster.local so that the DNS request is not forwarded to the customer DNS server.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6346](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6346)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `beau`
  * Local development environment
  * Virtual Shasta

### Test description:

Deployed the new cray-istio-deploy chart, and verified that the new istio tracing address has been updated by running:
`kubectl -n istio-system get cm istio -o yaml`

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

