### PR TITLE
CASMPET-7248: Use apiVersion autoscaling/v2 for HorizontalPodAutoscaler

### DIFF
--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 3.0.1
+version: 3.1.0
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/Chart.yaml
+++ b/kubernetes/cray-istio/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 3.0.0
+version: 3.0.1
 name: cray-istio
 description: Cray Istio for cluster service mesh including service gateway/sidecars, monitoring etc.
 keywords:

--- a/kubernetes/cray-istio/templates/ingress-gateway/autoscale.yaml
+++ b/kubernetes/cray-istio/templates/ingress-gateway/autoscale.yaml
@@ -1,11 +1,7 @@
 {{- range $name, $options:= .Values.deployments }}
 {{- if and $options.autoscaleEnabled $options.autoscaleMin $options.autoscaleMax }}
 ---
-{{- if and .Capabilities .Capabilities.KubeVersion (semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: autoscaling/v2
-{{- else }}
-apiVersion: autoscaling/v2beta2
-{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name }}


### PR DESCRIPTION
## Summary and Scope

In preparation for upgrading Kubernetes to 1.32 in CSM 1.7, the HorizontalPodAutoscaler apiVersion has been changed to autoscaling/v2 (which has been available since k8s 1.23) since autoscaling/v2betav2 will no longer be available as of k8s 1.26.

The if-statement to select autoscaling/v2betav2 or autoscaling/v2 in the kubernetes/cray-istio/templates/autoscale.yaml
template does not work using helm on a system per [CASMPET-7248](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7248). 

## Issues and Related PRs

* Resolves [CASMPET-7248](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7248)

## Testing

Tested on `beau` with `helm upgrade`.  You can see the warnings about `autoscaling/v2beta2` on rollback.

```
pit:~/studenym # helm upgrade -n istio-system cray-istio cray-istio-3.0.1-20250116183846+cbf8356.tgz
Release "cray-istio" has been upgraded. Happy Helming!
NAME: cray-istio
LAST DEPLOYED: Thu Jan 16 19:25:06 2025
NAMESPACE: istio-system
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
A Cray-specific Istio chart
pit:~/studenym # helm list -n istio-system
NAME               	NAMESPACE   	REVISION	UPDATED                                	STATUS  	CHART                                  	APP VERSION
cray-istio         	istio-system	2       	2025-01-16 19:25:06.489437476 +0000 UTC	deployed	cray-istio-3.0.1-20250116183846+cbf8356	1.19.10
cray-istio-deploy  	istio-system	1       	2025-01-13 14:30:55.632653297 +0000 UTC	deployed	cray-istio-deploy-2.0.1                	1.19.10
cray-istio-operator	istio-system	1       	2025-01-13 14:30:53.556527841 +0000 UTC	deployed	cray-istio-operator-2.0.0              	1.19.10
pit:~/studenym # helm history -n istio-system cray-istio
REVISION	UPDATED                 	STATUS    	CHART                                  	APP VERSION	DESCRIPTION
1       	Mon Jan 13 14:33:26 2025	superseded	cray-istio-3.0.0                       	1.19.10    	Install complete
2       	Thu Jan 16 19:25:06 2025	deployed  	cray-istio-3.0.1-20250116183846+cbf8356	1.19.10    	Upgrade complete
pit:~/studenym # helm rollback -n istio-system cray-istio 1
W0116 19:41:37.899734    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:37.922915    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:37.961895    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:37.974514    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:37.986042    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.030097    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.051505    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.075605    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.095884    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.107726    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.114586    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.120408    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
Rollback was a success! Happy Helming!
pit:~/studenym #
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

